### PR TITLE
Add initial support for Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,40 @@
 # BukuRain
 
-BukuRain (Book Online) is a CLI tool written in javascript that helps you with generation of static html pages from any text file you provide. 
+BukuRain (Book Online) is a CLI tool written in javascript that helps you with generation of static html pages from any text file you provide.
 
 ## Installation
+
 ##### Before instalation make sure to download ode for your PC using the following link: https://nodejs.dev/
+
 1. Clone the repository to your computer
 2. Using CLI of your choice navigate to the directory where the repository was cloned into.
-3. Run ``npm install -g`` or ``npm i -g`` to download the dependencies globally
+3. Run `npm install -g` or `npm i -g` to download the dependencies globally
 4. Run buku for help
 
 ## Usage
+
 BukuRain accepts the following options:
 
-* `-v` or `--version`: Print the version of the package
-* `-h` or `--help`: Print help useful help message
-* `-i` or `--input`: Generate HTML files from TXT files. FILE PATH can be a path to an individual file, or to a folder
-* `-o` or `--output`: Name of the output directory. Default is './dist', followed by `-i` or `--input` FILE PATH
+- `-v` or `--version`: Print the version of the package
+- `-h` or `--help`: Print help useful help message
+- `-i` or `--input`: Generate HTML files from TXT files. FILE PATH can be a path to an individual file, or to a folder. Also, MD file is able to be converted into the .HTML.
+- `-o` or `--output`: Name of the output directory. Default is './dist', followed by `-i` or `--input` FILE PATH
 
-## Examples 
-``buku -v``
+## Examples
 
-``buku -h`` 
+`buku -v`
 
-``buku -i .\examples``
+`buku -h`
 
-``buku -i .\examples\paragraphs.txt``
+`buku -i .\examples`
 
-``buku -o .\test -i .\examples\paragraphs.txt``
-  
+`buku -i .\examples\paragraphs.txt` || `buku -i .\examples\test.md`
+
+`buku -o .\test -i .\examples\paragraphs.txt`
+
 ## Features
+
 As of release 0.0.1 BukuRain can:
 
-  - allow the user to specify a different output directory using ``--output`` or ``-o``
-  - mark the first line as the title of the page, as long as first line followed by two blank lines
-
+- allow the user to specify a different output directory using `--output` or `-o`
+- mark the first line as the title of the page, as long as first line followed by two blank lines

--- a/examples/test.md
+++ b/examples/test.md
@@ -11,3 +11,5 @@ second paragraph from md file
 third paragraph from md file
 
 _Italic font_
+
+String _Italic font_ String

--- a/examples/test.md
+++ b/examples/test.md
@@ -1,0 +1,13 @@
+# Heading 1
+
+## Heading 2
+
+### Heading 3
+
+first paragraph from md file
+
+second paragraph from md file
+
+third paragraph from md file
+
+_Italic font_

--- a/src/generator.js
+++ b/src/generator.js
@@ -4,13 +4,13 @@ const path = require("path");
 
 import { display } from "./commands.js";
 import { createRequire } from "module";
-import { parseToHtml, parseFileName } from "./parser.js";
+import { parseToHtml, parseFileName, mdParseToHtml } from "./parser.js";
 import { createSpinner } from "nanospinner";
 
 let distPath = "./dist";
 
-async function createFile(path) {
-  const data = fs.readFileSync(path, "utf-8");
+async function createFile(filePath) {
+  const data = fs.readFileSync(filePath, "utf-8");
   let content;
 
   if (process.platform === "linux" || process.platform === "darwin") {
@@ -18,11 +18,17 @@ async function createFile(path) {
   } else if (process.platform === "win32") {
     content = data.split("\r\n\r\n");
   }
-
-  fs.writeFile(
-    `${distPath}/${parseFileName(path)}.html`,
-    parseToHtml(content, path)
-  );
+  if (path.extname(filePath) === ".txt") {
+    fs.writeFile(
+      `${distPath}/${parseFileName(filePath)}.html`,
+      parseToHtml(content, filePath)
+    );
+  } else if (path.extname(filePath) === ".md") {
+    fs.writeFile(
+      `${distPath}/${parseFileName(filePath)}.html`,
+      mdParseToHtml(content, filePath)
+    );
+  }
 }
 
 async function viewDirectory(dirPath) {
@@ -56,6 +62,10 @@ async function main(filePath, directory) {
       await sleep();
       spinner.success({ text: `Success files were created in ${distPath}` });
     } else if (stats.isFile() && path.extname(filePath) === ".txt") {
+      await createFile(filePath);
+      await sleep();
+      spinner.success({ text: `Success file was created in ${distPath}` });
+    } else if (stats.isFile() && path.extname(filePath) === ".md") {
       await createFile(filePath);
       await sleep();
       spinner.success({ text: `Success file was created in ${distPath}` });

--- a/src/parser.js
+++ b/src/parser.js
@@ -39,22 +39,24 @@ function mdParseToHtml(content, filename) {
   content.pop();
   content.push(str);
 
+  let slicedLine;
+
+  const italic = /\_([^*><]+)\_/g;
+
   // to convert md lines to html tags
   const htmlContent = content
     .map((line) => {
       if (line.startsWith("# ")) {
-        var slicedLine = line.slice(2);
+        slicedLine = line.slice(2);
         return `<h1>${slicedLine}</h1>`;
       } else if (line.startsWith("## ")) {
-        var slicedLine = line.slice(3);
+        slicedLine = line.slice(3);
         return `<h2>${slicedLine}</h2>`;
       } else if (line.startsWith("### ")) {
-        var slicedLine = line.slice(3);
+        slicedLine = line.slice(3);
         return `<h3>${slicedLine}</h3>`;
-      } else if (line.startsWith("_") && line.endsWith("_")) {
-        var slicedLine = line.slice(1);
-        slicedLine = slicedLine.slice(0, -1);
-        return `<i>${slicedLine}</i>`;
+      } else if (line.match(italic)) {
+        return line.replace(italic, "<i>$1</i>");
       } else {
         return `<p>${line}</p>`;
       }

--- a/src/parser.js
+++ b/src/parser.js
@@ -30,10 +30,55 @@ function parseToHtml(content, filename) {
     </html>`;
 }
 
+function mdParseToHtml(content, filename) {
+  let title = parseFileName(filename);
+
+  // to remove \r\n at the end of content
+  let str = content.slice(-1).toString();
+  str = str.slice(0, -2);
+  content.pop();
+  content.push(str);
+
+  // to convert md lines to html tags
+  const htmlContent = content
+    .map((line) => {
+      if (line.startsWith("# ")) {
+        var slicedLine = line.slice(2);
+        return `<h1>${slicedLine}</h1>`;
+      } else if (line.startsWith("## ")) {
+        var slicedLine = line.slice(3);
+        return `<h2>${slicedLine}</h2>`;
+      } else if (line.startsWith("### ")) {
+        var slicedLine = line.slice(3);
+        return `<h3>${slicedLine}</h3>`;
+      } else if (line.startsWith("_") && line.endsWith("_")) {
+        var slicedLine = line.slice(1);
+        slicedLine = slicedLine.slice(0, -1);
+        return `<i>${slicedLine}</i>`;
+      } else {
+        return `<p>${line}</p>`;
+      }
+    })
+    .join("\n");
+
+  return `
+    <!doctype html>
+    <html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <title>${title}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <body>
+    ${htmlContent}
+    </body>
+    </html>`;
+}
+
 function parseFileName(path) {
   const filenameRegex = /[\\/](?:([^\\/]+))\.\w+$/;
   let name = path.match(filenameRegex);
   return name[1];
 }
 
-export { parseToHtml, parseFileName };
+export { parseToHtml, parseFileName, mdParseToHtml };


### PR DESCRIPTION
Fixes #4 
- Added a new feature for the tool to be able to convert the MD file to .HTML, and mdParseToHtml() is added to paser.js and it is used to convert the content of .MD file to HTML tag line by line.
- Updated README.md to show for the changes.